### PR TITLE
Swapping the install order of yarn and bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 script:
-- yarn install
 - bundle install
+- yarn install
 - RAILS_ENV=test bundle exec rake db:create db:migrate
 - bundle exec rspec
 after_script:
@@ -21,8 +21,8 @@ deploy:
     # dev: presencechecker-staging
     master: presence-prod
   run:
-  - yarn install
   - bundle install
+  - yarn install
   - bundle exec rake db:migrate
   - bundle exec rake assets:precompile
   - restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 script:
-- bundle install
 - yarn install
+- bundle install
 - RAILS_ENV=test bundle exec rake db:create db:migrate
 - bundle exec rspec
 after_script:
@@ -21,8 +21,8 @@ deploy:
     # dev: presencechecker-staging
     master: presence-prod
   run:
-  - bundle install
   - yarn install
+  - bundle install
   - bundle exec rake db:migrate
   - bundle exec rake assets:precompile
   - restart

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,24 +1,12 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+//*= require_tree .
+//*= require_self
 
 @import './react-datepicker-cssmodules.min.css';
 @import './react-datepicker.min.css';
-@import './lists.scss';
-@import './components.scss';
-@import './utils.scss';
+
+@import './lists';
+@import './components';
+@import './utils';
 
 *,
 a {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,7 +19,8 @@
 @import './lists.scss';
 @import './components.scss';
 @import './utils.scss';
-*/
+
+*,
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
`application.css` needs to be `application.scss` so that Webpacker knows to use the node scss method for grabbing imports rather than plain CSS's `@import` directive.

> "Sometimes, all you need is an extra S."
  \- Mischa