### PR TITLE
User should not be able to delete themselves

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@
 
 class UsersController < ApplicationController
   before_action :set_user, only: %i[destroy]
+  before_action :set_current_user, only: %i[index]
 
   def index
     @users = User.order(:email)
@@ -13,6 +14,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def set_current_user
+    @current_user = current_user
+  end
 
   def set_user
     @user = User.find(params[:id])

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -5,16 +5,18 @@
   = link_to new_user_invitation_path do
     Invite new users
 
-    %table.pure-table.pure-table-horizontal
-      %thead
-        %tr
-          %th Email
-
-      %tbody
-        - @users.each do |user|
+    - unless @users.blank?
+      %table.pure-table.pure-table-horizontal
+        %thead
           %tr
-            %td= user.email
-            %td
-              = link_to user_path(user), method: :delete, data: { confirm: 'Are you sure?' },
-                class: 'pure-button' do
-                delete
+            %th Email
+
+        %tbody
+          - @users.each do |user|
+            %tr
+              %td= user.email
+              %td
+                - if user != @current_user
+                  = link_to user_path(user), method: :delete, data: { confirm: 'Are you sure?' },
+                    class: 'pure-button' do
+                    delete

--- a/spec/views/users/index.html.haml_spec.rb
+++ b/spec/views/users/index.html.haml_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'users/index', type: :view do
+  include Devise::Test::ControllerHelpers
+  describe 'user deletion' do
+    let(:current_user) { FactoryBot.create :user }
+    let(:other_user) { FactoryBot.create :user }
+
+    before do
+      assign(:users, [current_user, other_user])
+      sign_in current_user
+    end
+
+    it 'allows for deletion of users' do
+      render
+      expect(rendered).to have_link 'delete'
+    end
+
+    it 'doesn\'t allow for deletion of self' do
+      assign(:current_user, current_user)
+      render
+      expect(rendered).to have_selector('a[data-method="delete"]', count: 1)
+    end
+  end
+end


### PR DESCRIPTION
When viewing the "Users" page, delete links are present for all users except the one currently logged in.
Closes #112 
![screen shot 2018-12-10 at 3 11 28 pm](https://user-images.githubusercontent.com/16579534/49706981-0983fa80-fc8e-11e8-9516-781556c2c0fe.png)