### PR TITLE
Auto corrected by following Ruby RSpecEmptyLine

### DIFF
--- a/spec/services/eligibility_service_spec.rb
+++ b/spec/services/eligibility_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe EligibilityService, type: :model do
         FactoryBot.create :departure, carrier_date_time: '2018-05-01', identity: identity
         FactoryBot.create :arrival, carrier_date_time: '2018-05-16', identity: identity
       end
+
       it { expect(client.movements.count).to eq 3 }
       it { expect(service.send(:presence_values)).to eq('2018-01-01' => true, '2018-05-02' => false, '2018-05-16' => true) }
     end
@@ -29,6 +30,7 @@ RSpec.describe EligibilityService, type: :model do
 
     context 'when not present in nz' do
       before { service.run! }
+
       it "Adds up the previous 5 years to all be zero" do
         expect(service.days_by_rolling_year).to eq('2015-06-01' => 0, '2016-06-01' => 0, '2017-06-01' => 0, '2018-06-01' => 0, '2019-06-01' => 0)
       end
@@ -41,6 +43,7 @@ RSpec.describe EligibilityService, type: :model do
         FactoryBot.create :arrival, carrier_date_time: '2011-01-01', identity: identity
         service.run!
       end
+
       it "Adds up the previous 5 years to all be present" do
         expect(service.days_by_rolling_year).to eq('2015-06-01' => 365, '2016-06-01' => 366, '2017-06-01' => 365, '2018-06-01' => 365, '2019-06-01' => 365)
       end
@@ -55,6 +58,7 @@ RSpec.describe EligibilityService, type: :model do
         FactoryBot.create :arrival, carrier_date_time: '2016-04-01', identity: identity
         service.run!
       end
+
       it "works out the absence for 4 months" do
         expect(service.days_by_rolling_year).to eq('2015-06-01' => 365, '2016-06-01' => 276, '2017-06-01' => 365, '2018-06-01' => 365, '2019-06-01' => 365)
       end


### PR DESCRIPTION
Auto corrected by following Ruby RSpecEmptyLine

Click [here](https://awesomecode.io/repos/ServiceInnovationLab/PresenceChecker/ruby_config_groups/791) to configure it on awesomecode.io