### PR TITLE
Movements table scroll container

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -301,8 +301,8 @@ table {
     padding-left: 10px;
   }
 
-  .is-header{
-    width:55%;
+  .is-header {
+    width: 55%;
   }
 
   header {
@@ -329,29 +329,29 @@ table {
   .year-table {
     width: 100%;
     border-spacing: 0px;
-    color:$white;
+    color: $white;
 
-    &__summary{
-      padding:20px;
+    &__summary {
+      padding: 20px;
       text-align: left;
     }
 
     &.has-error {
-      color:$black;
-      tr{
+      color: $black;
+
+      tr {
         background: $yellow-negative;
       }
     }
 
     .is-light {
-      color:$black;
+      color: $black;
       background-color: $light-white;
     }
+
     tr {
-      background:$blue-positive;
+      background: $blue-positive;
     }
-
-
 
     .icon-container {
       width: 10%;
@@ -438,19 +438,30 @@ table {
   }
 }
 
-
 .movements-table {
-  margin: 20px 0;
-  header {
-    background: $light-blue;
-    color: $dark-grey;
-  }
-  td {
-    background: $even-lighter-grey;
-    color: $dark-grey;
-  }
   h3 {
+    padding: 0 20px;
     text-align: left;
-    padding-left: 20px;
   }
+
+  tr:nth-of-type(even) {
+    background-color: rgba($black, .05);
+  }
+}
+
+.movements-table-header {
+  margin-top: 20px;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.movements-table-wrapper {
+  max-height: 30rem;
+  overflow: hidden;
+  overflow-y: auto;
+  margin-bottom: 20px;
+  border: 2px solid $light-grey;
+  border-top: 0;
 }

--- a/app/javascript/bundles/Presence/components/MovementsTable.jsx
+++ b/app/javascript/bundles/Presence/components/MovementsTable.jsx
@@ -1,38 +1,43 @@
 import React from 'react';
 import { format } from 'date-fns';
 
-class MovementsTable extends React.Component {
+import Table from '../../../components/Table';
 
+class MovementsTable extends React.Component {
   render() {
-    const {movements} = this.props;
+    const { movements } = this.props;
+
     return (
-      <div>
-        <table className="presence-table movements-table" cellpadding="0" cellspacing="0">
-          <tbody>
-            <tr colSpan="4">
-              <th>
-                <header>
-                  <span>Movements</span>
-                </header>
-              </th>
-            </tr>
-            {movements.map(item => <tr>
-              <td>
-                <table className="year-table is-text-center" cellpadding="0" cellspacing="0">
-                  <tbody>
-                    <tr>
-                      <td style={{width: '20%'}} className="header-container has-bottom-border has-right-border">
-                        <h3 className="is-dark">{item.direction.charAt(0).toUpperCase() + item.direction.slice(1)}</h3>
-                      </td>
-                      <td className="has-bottom-border">{format(item.carrier_date_time, 'DD MMM YYYY')}</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </td>
-            </tr>)}
-          </tbody>
-        </table>
-      </div>
+      <section className="movements-table-area">
+        <header className="movements-table-header">
+          <h2>Movements</h2>
+        </header>
+
+        <div className="movements-table-wrapper">
+          <Table
+            className="presence-table movements-table"
+            cellpadding="0"
+            cellspacing="0"
+          >
+            {movements.map((item) => (
+              <tr>
+                <td
+                  style={{ width: '20%' }}
+                  className="header-container has-bottom-border has-right-border"
+                >
+                  <h3 className="is-dark">
+                    {item.direction.charAt(0).toUpperCase() +
+                      item.direction.slice(1)}
+                  </h3>
+                </td>
+                <td className="has-bottom-border">
+                  {format(item.carrier_date_time, 'DD MMM YYYY')}
+                </td>
+              </tr>
+            ))}
+          </Table>
+        </div>
+      </section>
     );
   }
 }

--- a/app/javascript/bundles/Presence/components/MovementsTable.jsx
+++ b/app/javascript/bundles/Presence/components/MovementsTable.jsx
@@ -21,10 +21,7 @@ class MovementsTable extends React.Component {
           >
             {movements.map((item) => (
               <tr>
-                <td
-                  style={{ width: '20%' }}
-                  className="header-container has-bottom-border has-right-border"
-                >
+                <td className="header-container has-bottom-border has-right-border">
                   <h3 className="is-dark">
                     {item.direction.charAt(0).toUpperCase() +
                       item.direction.slice(1)}


### PR DESCRIPTION
- Rearranged components to take out the table-in-table structure so that columns size automatically.
- Added missing styles for borders, alternating rows, wrapped core table in scroll container.

Before scroll:
![screen shot 2018-12-12 at 12 48 03 pm](https://user-images.githubusercontent.com/16579534/49837696-3fe78400-fe0c-11e8-9ec7-ebc6398e4203.png)

During scroll:
![screen shot 2018-12-12 at 12 48 11 pm](https://user-images.githubusercontent.com/16579534/49837701-470e9200-fe0c-11e8-9191-0e2f57e845a8.png)
