### PR TITLE
Enforce half decent passwords

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable,
          :recoverable, :rememberable, :validatable
+  validate :password_complexity
+
+  def password_complexity
+    # Regexp extracted from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
+    return if password.blank? || password =~ /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/
+
+    errors.add(:password,
+               'Complexity requirement not met. Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character')
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'requires good passwords' do
+    it 'accepts good passwords' do
+      expect { FactoryBot.create :user, password: 'P@ssw0rd}' }.not_to raise_error
+    end
+    it 'rejects blank passwords' do
+      expect { FactoryBot.create :user, password: '' }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+    it 'rejects alpha only' do
+      expect { FactoryBot.create :user, password: 'Password}' }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+    it 'rejects when no number' do
+      expect { FactoryBot.create :user, password: 'P@ssword}' }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+    it 'rejects when no Upper case' do
+      expect { FactoryBot.create :user, password: 'p@ssw0rd}}' }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe User, type: :model do
     it 'rejects blank passwords' do
       expect { FactoryBot.create :user, password: '' }.to raise_error(ActiveRecord::RecordInvalid)
     end
+    it 'rejects short passwords' do
+      expect { FactoryBot.create :user, password: 'P@0' }.to raise_error(ActiveRecord::RecordInvalid)
+    end
     it 'rejects alpha only' do
       expect { FactoryBot.create :user, password: 'Password}' }.to raise_error(ActiveRecord::RecordInvalid)
     end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user, aliases: [:owner] do
     email { Faker::Internet.email }
-    password { Faker::Internet.password }
+    password { "#{Faker::Internet.password}P@ssw0rd}" }
     # after(:create) do |user, _evaluator|
     #   user.confirm
     # end


### PR DESCRIPTION
"Complexity requirement not met. Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character"