### PR TITLE
Feature/scenarios

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -20,14 +20,16 @@ class ClientsController < ApplicationController
     end
     render json: {
       requested_day => {
-        # boolean
         'meetsMinimumPresence' => @eligibility.minimum_presence,
-        # boolean
+        # boolean (root)
         'meetsFiveYearPresence' => @eligibility.five_year_presence,
-        # hash of booleans e.g. {'2019-06-07': true.. }
-        'last5Years' => @eligibility.mimimum_presence_by_rolling_year,
-        # hash of integers e.g. {'2019-06-07': 365.. }
-        'daysInNZ' => @eligibility.present_days_by_rolling_year
+        # boolean (child of root | parent of present_days_by_rolling_year)
+        'daysInNZ' => @eligibility.present_days_by_rolling_year,
+        # hash of integers e.g. {'2019-06-07': 365.. } (child of five_year_presence)
+        'eachYearPresence' => @eligibility.each_year_presence,
+        # boolean (child of root | parent of mimimum_presence_by_rolling_year)
+        'last5Years' => @eligibility.mimimum_presence_by_rolling_year
+        # hash of booleans e.g. {'2019-06-07': true.. } (child of each_year_presence)
       }
     }
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,6 +16,7 @@ export default class ShowClient extends React.Component {
     backgroundLoading: false,
     selectedDate: new Date(),
     meetsMinimumPresence: false,
+    meetsFiveYearPresence: false,
     daysInNZ: {},
     last5Years: {},
     futureEligibility: [],
@@ -74,6 +75,7 @@ export default class ShowClient extends React.Component {
       meetsMinimumPresence: response.meetsMinimumPresence,
       daysInNZ: response.daysInNZ,
       last5Years: response.last5Years,
+      meetsFiveYearPresence: response.meetsFiveYearPresence 
     });
 
     this.checkNextWeek();
@@ -151,6 +153,7 @@ export default class ShowClient extends React.Component {
     const {
       selectedDate,
       meetsMinimumPresence,
+      meetsFiveYearPresence,
       daysInNZ,
       last5Years,
       loading,
@@ -175,7 +178,7 @@ export default class ShowClient extends React.Component {
           </div>
           <div className="results dates-wrapper-right">
             <PresenceTable
-              isEligible={meetsMinimumPresence}
+              isEligible={meetsFiveYearPresence}
               totalDays={daysInNZ}
               years={last5Years}
               selectedDate={selectedDate}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  # config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,7 +38,15 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # Don't care if the mailer can't send.
+
+  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -244,6 +244,9 @@ FactoryBot.create :arrival, carrier_date_time: '18 Feb 2013', identity: identity
 
 FactoryBot.create :departure, carrier_date_time: '29 Jan 2018', identity: identity
 FactoryBot.create :arrival, carrier_date_time: '01 Oct 2018', identity: identity
+
+# We should have think about randomisation along these lines
+# Would complicate consistent testing across multiple seed instances
 # holiday_length =  Random.rand(10...42)
 # holiday_start = Random.rand(50...100)
 # holiday_end = holiday_start - holiday_length

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -146,10 +146,11 @@ FactoryBot.create :arrival, carrier_date_time: '12 Aug 2018', identity: identity
 # Customers are away for periods of time but still meet presence requirements on the 5th November 2018
 
 ##### Expected results #####
-# Applicant still meets presence requirements on the 5th November 2018 
+# Applicant still meets presence requirements on the 5th November 2018
 # (these dates were tested in Bruteforce)
 
-identity = FactoryBot.create :identity, family_name: 'Criteria', first_name: 'Meets', second_name: '', third_name: ''
+client_1 = FactoryBot.create :client, im_client_id: '54321', file_number: '1'
+identity = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Criteria', first_name: 'Meets', second_name: '', third_name: ''
 
 FactoryBot.create :arrival, carrier_date_time: '20 Jan 2013', identity: identity
 FactoryBot.create :departure, carrier_date_time: '10 Jan 2015', identity: identity
@@ -178,7 +179,8 @@ FactoryBot.create :arrival, carrier_date_time: '5 Aug 2018', identity: identity
 # Applicant doesn’t meet presence requirements on the 5th November 2018
 #(these dates were tested in Bruteforce)
 
-identity = FactoryBot.create :identity, family_name: 'Criteria', first_name: 'Does', second_name: 'Not', third_name: 'Meet'
+client_1 = FactoryBot.create :client, im_client_id: '56789', file_number: '1'
+identity = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Criteria', first_name: 'Does', second_name: 'Not', third_name: 'Meet'
 
 FactoryBot.create :arrival, carrier_date_time: '20 Jan 2013', identity: identity
 FactoryBot.create :departure, carrier_date_time: '30 Jan 2015', identity: identity
@@ -208,9 +210,9 @@ FactoryBot.create :arrival, carrier_date_time: '24 Aug 2018', identity: identity
 ##### Expected results #####
 #Only eligible between June 8th and September 27
 
-client_2 = FactoryBot.create :client, im_client_id: '123456', file_number: '2'
-identity_3 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'James', second_name: '', third_name: '', gender: 'Male'
-identity_4 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'Jaymie', second_name: '', third_name: '', gender: 'Female'
+client_1 = FactoryBot.create :client, im_client_id: '581119', file_number: '2'
+identity_3 = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Jones', first_name: 'James', second_name: '', third_name: '', gender: 'Male'
+identity_4 = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Jones', first_name: 'Jaymie', second_name: '', third_name: '', gender: 'Female'
 FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 312.weeks.ago
 FactoryBot.create :departure, identity: identity_3, carrier_date_time: 300.weeks.ago
 FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 280.weeks.ago
@@ -225,31 +227,36 @@ FactoryBot.create :arrival, identity: identity_4, carrier_date_time: 70.weeks.ag
 
 ##### Expected results #####
 # Eligible
-identity = FactoryBot.create :identity, family_name: 'Okay', first_name: 'Simply', second_name: '', third_name: ''
+client_1 = FactoryBot.create :client, im_client_id: '93251', file_number: '2'
+identity = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Okay', first_name: 'Simply', second_name: '', third_name: ''
 FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
 
 ####### Test scenario #12 #######
-# Arrived more than five years ago and never left
+# Arrived more than five years ago
 # Only one period overseas which was short enough to meet presence criteria
 
 ##### Expected results #####
-# Eligible
-identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Short', second_name: '', third_name: ''
-FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
+# Eligible before June 2, 2018 and each year after
+# between May 28 2019 and  June 2 2019 (inclusive)
+client_1 = FactoryBot.create :client, im_client_id: '821313', file_number: '2'
+identity = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Holiday', first_name: 'Short', second_name: '', third_name: ''
+FactoryBot.create :arrival, carrier_date_time: '18 Feb 2013', identity: identity
 
-holiday_length =  Random.rand(10...42)
-holiday_start = Random.rand(50...100)
-holiday_end = holiday_start - holiday_length
-
-FactoryBot.create :departure, carrier_date_time: holiday_start.weeks.ago, identity: identity
-FactoryBot.create :arrival, carrier_date_time: holiday_end.weeks.ago, identity: identity
+FactoryBot.create :departure, carrier_date_time: '29 Jan 2018', identity: identity
+FactoryBot.create :arrival, carrier_date_time: '01 Oct 2018', identity: identity
+# holiday_length =  Random.rand(10...42)
+# holiday_start = Random.rand(50...100)
+# holiday_end = holiday_start - holiday_length
+# FactoryBot.create :departure, carrier_date_time: holiday_start.weeks.ago, identity: identity
+# FactoryBot.create :arrival, carrier_date_time: holiday_end.weeks.ago, identity: identity
 
 ####### Test scenario #13 #######
 # Was overseas for more than 1 year during preceeding 5 years
 
 ##### Expected results #####
 # Not Eligible
-identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Too', second_name: 'Long', third_name: ''
+client_1 = FactoryBot.create :client, im_client_id: '723123', file_number: '2'
+identity = FactoryBot.create :identity, client_id: client_1.id, family_name: 'Holiday', first_name: 'Too', second_name: 'Long', third_name: ''
 FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
 
 holiday_start = 140.weeks.ago

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-['brenda.wallace', 'dana.iti'].each do |name|
-  email = "#{name}@dia.govt.nz"
-  User.invite!(email: email) unless User.find_by(email: email)
-end
+# ['brenda.wallace', 'dana.iti'].each do |name|
+#   email = "#{name}@dia.govt.nz"
+#   User.invite!(email: email) unless User.find_by(email: email)
+# end
 
 ####### Test scenario #1 #######
 # Customer travels in and out of NZ as a Flight Attendant.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,76 +5,31 @@
   User.invite!(email: email) unless User.find_by(email: email)
 end
 
-# James Jones
-# Gender change from Male to Female
-# Total days in NZ meets criteria (1492 of 1250)
-# Is only eligible between June 8th and September 27
-
-client_2 = FactoryBot.create :client, im_client_id: '123456', file_number: '2'
-identity_3 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'James', gender: 'Male'
-identity_4 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'Jaymie', gender: 'Female'
-FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 312.weeks.ago
-FactoryBot.create :departure, identity: identity_3, carrier_date_time: 300.weeks.ago
-FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 280.weeks.ago
-
-FactoryBot.create :departure, identity: identity_4, carrier_date_time: 156.weeks.ago
-FactoryBot.create :arrival, identity: identity_4, carrier_date_time: 148.weeks.ago
-FactoryBot.create :departure, identity: identity_4, carrier_date_time: 90.weeks.ago
-FactoryBot.create :arrival, identity: identity_4, carrier_date_time: 70.weeks.ago
-
-# Arrived and never left
-# Eligible
-identity = FactoryBot.create :identity, family_name: 'Okay', first_name: 'Simply'
-FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
-
-# Arrived, had only one holiday
-# Eligible
-identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Short'
-FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
-
-holiday_length =  Random.rand(10...42)
-holiday_start = Random.rand(50...100)
-holiday_end = holiday_start - holiday_length
-
-FactoryBot.create :departure, carrier_date_time: holiday_start.weeks.ago, identity: identity
-FactoryBot.create :arrival, carrier_date_time: holiday_end.weeks.ago, identity: identity
-
-# Took a really long holiday during
-# Not Eligible
-identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Too', second_name: 'Long'
-FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
-
-holiday_start = 140.weeks.ago
-holiday_end = 75.weeks.ago
-
-FactoryBot.create :departure, carrier_date_time: holiday_start, identity: identity
-FactoryBot.create :arrival, carrier_date_time: holiday_end, identity: identity
-
 ####### Test scenario #1 #######
 # Customer travels in and out of NZ as a Flight Attendant.
 # There are cases when an attendant doesn’t register as coming in or out of the country.
 # For example records can show that they depart, then depart again, without arriving in between. 
-# *Hazel said: This is out of scope.
 # This would also be at the discretion of the minister.
 # However lets run the data through the system and see if we can break it
-# Expected results
+
+####### Expected Results #######
 # Alert message to prompt a query into this person travel reasons.
 # Suggested reasons being that the person may be a flight attendant/pilot.
 
-identity = FactoryBot.create :identity, family_name: 'Attendant', first_name: 'Flight', second_name: '', third_name: ''
-FactoryBot.create :arrival, carrier_date_time: '20 Jan 2013', identity: identity
-FactoryBot.create :departure, carrier_date_time: '9 Mar 2014', identity: identity
-FactoryBot.create :departure, carrier_date_time: '20 Jan 2014', identity: identity
-FactoryBot.create :arrival, carrier_date_time: '9 Mar 2015', identity: identity
-FactoryBot.create :departure, carrier_date_time: '20 Jan 2015', identity: identity
-FactoryBot.create :departure, carrier_date_time: '9 Mar 2016', identity: identity
-FactoryBot.create :arrival, carrier_date_time: '15 Mar 2016', identity: identity
-FactoryBot.create :departure, carrier_date_time: '26 Aug 2016', identity: identity
-FactoryBot.create :arrival, carrier_date_time: '30 Aug 2015', identity: identity
-FactoryBot.create :departure, carrier_date_time: '1 Nov 2016', identity: identity
-FactoryBot.create :departure, carrier_date_time: '16 Nov 2016', identity: identity
-FactoryBot.create :departure, carrier_date_time: '26 May 2017', identity: identity
-FactoryBot.create :arrival, carrier_date_time: '20 Jun 2017', identity: identity
+# identity = FactoryBot.create :identity, family_name: 'Attendant', first_name: 'Flight', second_name: '', third_name: ''
+# FactoryBot.create :arrival, carrier_date_time: '20 Jan 2013', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '9 Mar 2014', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '20 Jan 2014', identity: identity
+# FactoryBot.create :arrival, carrier_date_time: '9 Mar 2015', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '20 Jan 2015', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '9 Mar 2016', identity: identity
+# FactoryBot.create :arrival, carrier_date_time: '15 Mar 2016', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '26 Aug 2016', identity: identity
+# FactoryBot.create :arrival, carrier_date_time: '30 Aug 2015', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '1 Nov 2016', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '16 Nov 2016', identity: identity
+# FactoryBot.create :departure, carrier_date_time: '26 May 2017', identity: identity
+# FactoryBot.create :arrival, carrier_date_time: '20 Jun 2017', identity: identity
 
 ####### Test scenario #2 #######
 # Travel to one of the countries counted as NZ (Cook Islands, Niue, Tokelau & Antarctica).
@@ -108,13 +63,14 @@ FactoryBot.create :arrival, carrier_date_time: '20 Jun 2017', identity: identity
 
 # *Hazel says: There are rules that come from Legislation that can be automated. This is the Rules part of the engine model.
 # This is the first piece of work to be done on the project
+
 ####### Expected results #######
 # There is a flag raised in the system to show that these countries have been involved in the movements.
 
-
-####### Test scenario #4 #######
+###### Test scenario #4 #######
 # Customer has three passports and exits NZ on one, and returns to NZ on another.
 # On the passports they have different names.
+
 ##### Expected results ####
 # If there is the same Client ID number grouping these three identities, the departure and arrival dates should be consolidated into the movements table.
 
@@ -176,7 +132,6 @@ FactoryBot.create :arrival, carrier_date_time: '12 Aug 2018', identity: identity
 
 ####### Test scenario #6  ######
 # Customers are away for periods of time while working for the Crown / Military / Govt. 
-# *Hazel says: There are rules that come from Legislation that can be automated. This is the Rules part of the engine model. This is the first piece of work to be done on the project
 
 ####### Expected results ######
 # # There is a flag raised in the system to show that this person is traveling for Crown / Military / Govt reasons (need to discuss further, may be out of scope for this piece of work)
@@ -184,14 +139,15 @@ FactoryBot.create :arrival, carrier_date_time: '12 Aug 2018', identity: identity
 ####### Test scenario #7  ######
 # Customers are away for periods of time while their partner/parent is working for the Crown / Military / Govt
 
-# *Hazel says: There are rules that come from Legislation that can be automated. This is the Rules part of the engine model. This is the first piece of work to be done on the project
 ######## Expected results #######
 # There is a flag raised in the system to show that this person is a partner or child of a person who is traveling for Crown / Military / Govt reasons (need to discuss further, may be out of scope for this piece of work)
 
 ####### Test scenario #8 #######
 # Customers are away for periods of time but still meet presence requirements on the 5th November 2018
+
 ##### Expected results #####
-# Applicant still meets presence requirements  (these dates were tested in Bruteforce)
+# Applicant still meets presence requirements on the 5th November 2018 
+# (these dates were tested in Bruteforce)
 
 identity = FactoryBot.create :identity, family_name: 'Criteria', first_name: 'Meets', second_name: '', third_name: ''
 
@@ -215,10 +171,12 @@ FactoryBot.create :arrival, carrier_date_time: '20 May 2018', identity: identity
 FactoryBot.create :departure, carrier_date_time: '1 Aug 2018', identity: identity
 FactoryBot.create :arrival, carrier_date_time: '5 Aug 2018', identity: identity
 
-####### Test scenario #8 #######
+####### Test scenario #9 #######
 # Customers are away for periods of time and don’t meet presence requirements on the 5th November 2018
+
 ##### Expected results #####
-# Applicant doesn’t meet presence requirements (these dates were tested in Bruteforce)
+# Applicant doesn’t meet presence requirements on the 5th November 2018
+#(these dates were tested in Bruteforce)
 
 identity = FactoryBot.create :identity, family_name: 'Criteria', first_name: 'Does', second_name: 'Not', third_name: 'Meet'
 
@@ -241,3 +199,61 @@ FactoryBot.create :departure, carrier_date_time: '26 May 2018', identity: identi
 FactoryBot.create :arrival, carrier_date_time: '1 Jun 2018', identity: identity
 FactoryBot.create :departure, carrier_date_time: '19 Aug 2018', identity: identity
 FactoryBot.create :arrival, carrier_date_time: '24 Aug 2018', identity: identity
+
+####### Test scenario #10 #######
+# Gender change from Male to Female
+# Multiple 20 week vacations during preceeding 5 years
+# Total days in NZ meets criteria (1492 of 1250)
+
+##### Expected results #####
+#Only eligible between June 8th and September 27
+
+client_2 = FactoryBot.create :client, im_client_id: '123456', file_number: '2'
+identity_3 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'James', second_name: '', third_name: '', gender: 'Male'
+identity_4 = FactoryBot.create :identity, client_id: client_2.id, family_name: 'Jones', first_name: 'Jaymie', second_name: '', third_name: '', gender: 'Female'
+FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 312.weeks.ago
+FactoryBot.create :departure, identity: identity_3, carrier_date_time: 300.weeks.ago
+FactoryBot.create :arrival, identity: identity_3, carrier_date_time: 280.weeks.ago
+
+FactoryBot.create :departure, identity: identity_4, carrier_date_time: 156.weeks.ago
+FactoryBot.create :arrival, identity: identity_4, carrier_date_time: 148.weeks.ago
+FactoryBot.create :departure, identity: identity_4, carrier_date_time: 90.weeks.ago
+FactoryBot.create :arrival, identity: identity_4, carrier_date_time: 70.weeks.ago
+
+####### Test scenario #11 #######
+# Arrived more than five years ago and never left
+
+##### Expected results #####
+# Eligible
+identity = FactoryBot.create :identity, family_name: 'Okay', first_name: 'Simply', second_name: '', third_name: ''
+FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
+
+####### Test scenario #12 #######
+# Arrived more than five years ago and never left
+# Only one period overseas which was short enough to meet presence criteria
+
+##### Expected results #####
+# Eligible
+identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Short', second_name: '', third_name: ''
+FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
+
+holiday_length =  Random.rand(10...42)
+holiday_start = Random.rand(50...100)
+holiday_end = holiday_start - holiday_length
+
+FactoryBot.create :departure, carrier_date_time: holiday_start.weeks.ago, identity: identity
+FactoryBot.create :arrival, carrier_date_time: holiday_end.weeks.ago, identity: identity
+
+####### Test scenario #13 #######
+# Was overseas for more than 1 year during preceeding 5 years
+
+##### Expected results #####
+# Not Eligible
+identity = FactoryBot.create :identity, family_name: 'Holiday', first_name: 'Too', second_name: 'Long', third_name: ''
+FactoryBot.create :arrival, carrier_date_time: 6.years.ago, identity: identity
+
+holiday_start = 140.weeks.ago
+holiday_end = 75.weeks.ago
+
+FactoryBot.create :departure, carrier_date_time: holiday_start, identity: identity
+FactoryBot.create :arrival, carrier_date_time: holiday_end, identity: identity

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'rails_helper'
 RSpec.describe ClientsController, type: :controller do
   include Devise::Test::ControllerHelpers
@@ -15,6 +14,8 @@ RSpec.describe ClientsController, type: :controller do
   end
 
   context 'user is signed in' do
+    before { Rails.application.load_seed }
+
     before { sign_in user }
 
     describe 'GET show' do
@@ -116,6 +117,169 @@ RSpec.describe ClientsController, type: :controller do
             '2017-01-01' => 366,
             '2016-01-01' => 365,
             '2015-01-01' => 365
+          )
+        }
+      end
+
+      ###### Test scenario #4 #######
+      context 'Customer has three passports, same Client ID' do
+        it {
+          valid_date = Date.new(2017, 10, 2)
+          client = Client.find_by(im_client_id: '12345')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: valid_date.to_s }
+          res = JSON.parse(response.body)[valid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(true)
+          expect(res['eachYearPresence']).to eq(true)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            valid_date.to_s => true,
+            valid_date.prev_year.to_s => true,
+            valid_date.prev_year(2).to_s => true,
+            valid_date.prev_year(3).to_s => true,
+            valid_date.prev_year(4).to_s => true
+          )
+        }
+        it {
+          invalid_date = Date.new(2017, 10, 1)
+          client = Client.find_by(im_client_id: '12345')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: invalid_date.to_s }
+          res = JSON.parse(response.body)[invalid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(false)
+          expect(res['eachYearPresence']).to eq(false)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            invalid_date.to_s => true,
+            invalid_date.prev_year.to_s => true,
+            invalid_date.prev_year(2).to_s => true,
+            invalid_date.prev_year(3).to_s => true,
+            invalid_date.prev_year(4).to_s => false
+          )
+        }
+      end
+
+      ###### Test scenario #8 #######
+      context 'Customers are away for periods of time, dates tested in Bruteforce, meets presence requirements' do
+        it {
+          valid_date = Date.new(2018, 11, 5)
+          client = Client.find_by(im_client_id: '54321')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: valid_date.to_s }
+          res = JSON.parse(response.body)[valid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(true)
+          expect(res['eachYearPresence']).to eq(true)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            valid_date.to_s => true,
+            valid_date.prev_year.to_s => true,
+            valid_date.prev_year(2).to_s => true,
+            valid_date.prev_year(3).to_s => true,
+            valid_date.prev_year(4).to_s => true
+          )
+        }
+      end
+      ###### Test scenario #9 #######
+      context 'Customers are away for periods of time, dates tested in Bruteforce, does not meet presence requirements' do
+        it {
+          invalid_date = Date.new(2018, 11, 5)
+          client = Client.find_by(im_client_id: '56789')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: invalid_date.to_s }
+          res = JSON.parse(response.body)[invalid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(false)
+          expect(res['eachYearPresence']).to eq(false)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            invalid_date.to_s => true,
+            invalid_date.prev_year.to_s => false,
+            invalid_date.prev_year(2).to_s => true,
+            invalid_date.prev_year(3).to_s => true,
+            invalid_date.prev_year(4).to_s => true
+          )
+        }
+      end
+      ###### Test scenario #10 #######
+      context 'Multiple 20 week vacations, Only eligible between June 8th and September 27' do
+        it {
+          valid_date = Date.new(2018, 7, 8)
+          client = Client.find_by(im_client_id: '581119')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: valid_date.to_s }
+          res = JSON.parse(response.body)[valid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(true)
+          expect(res['eachYearPresence']).to eq(true)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            valid_date.to_s => true,
+            valid_date.prev_year.to_s => true,
+            valid_date.prev_year(2).to_s => true,
+            valid_date.prev_year(3).to_s => true,
+            valid_date.prev_year(4).to_s => true
+          )
+        }
+        it {
+          invalid_date = Date.new(2018, 3, 5)
+          client = Client.find_by(im_client_id: '581119')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: invalid_date.to_s }
+          res = JSON.parse(response.body)[invalid_date.to_s]
+          expect(res['meetsMinimumPresence']).to eq(false)
+          expect(res['eachYearPresence']).to eq(false)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            invalid_date.to_s => false,
+            invalid_date.prev_year.to_s => true,
+            invalid_date.prev_year(2).to_s => true,
+            invalid_date.prev_year(3).to_s => true,
+            invalid_date.prev_year(4).to_s => false
+          )
+        }
+      end
+      ####### Test scenario #12 #######
+      context 'Only one period overseas which was short enough' do
+        it {
+          valid_date = Date.new(2020, 6, 3)
+          client = Client.find_by(im_client_id: '821313')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: valid_date.to_s }
+          res = JSON.parse(response.body)[valid_date.to_s]
+          
+          expect(res['meetsMinimumPresence']).to eq(true)
+          expect(res['eachYearPresence']).to eq(true)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            valid_date.to_s => true,
+            valid_date.prev_year.to_s => true,
+            valid_date.prev_year(2).to_s => true,
+            valid_date.prev_year(3).to_s => true,
+            valid_date.prev_year(4).to_s => true
+          )
+        }
+      end
+      ####### Test scenario #13 #######
+      context 'Was overseas for more than 1 year' do
+        it {
+          valid_date = Date.new(2018, 7, 8)
+          client = Client.find_by(im_client_id: '723123')
+
+          get :eligibility, format: :json, params: { client_id: client.to_param, day: valid_date.to_s }
+          res = JSON.parse(response.body)[valid_date.to_s]
+
+          expect(res['meetsMinimumPresence']).to eq(false)
+          expect(res['eachYearPresence']).to eq(false)
+          expect(res['meetsFiveYearPresence']).to eq(true)
+          expect(res['last5Years']).to eq(
+            valid_date.to_s => true,
+            valid_date.prev_year.to_s => false,
+            valid_date.prev_year(2).to_s => true,
+            valid_date.prev_year(3).to_s => true,
+            valid_date.prev_year(4).to_s => true
           )
         }
       end

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe ClientsController, type: :controller do
           )
         }
         it {
+          pending 'waiting for open-fisca pr'
           invalid_date = Date.new(2017, 10, 1)
           client = Client.find_by(im_client_id: '12345')
 


### PR DESCRIPTION
- [ ] add tests to cover all seed data currently handled 
- [ ] add clean commenting and definition of presence variables 
- [ ] add mailer config for tests to enable use of seed data in tests
- [ ] update ui to use meetsFiveYearPresence variable

This pr includes one pending test: spec/controllers/clients_controller_spec.rb:144 which is waiting on a fix for the bug discovered to be implemented in openfisca

close #221 